### PR TITLE
[TENJIN-10105] Update Unity SDK to 1.12.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Unity SDK for Tenjin. To learn more about Tenjin and our product offering, p
 - For any issues or support, please contact: support@tenjin.com
 - **iOS Notes**:
 
-  - Xcode 12 requirement, if you’re using Unity iOS SDK v1.12.0 and higher.
+  - Xcode 13 requirement, if you’re using Unity iOS SDK v1.12.21 and higher.
   - When building iOS, confirm that these frameworks were automatically added to the Xcode build. If any are missing, you will need to add them manually.
 	- AdServices.framework
 	- AdSupport.framework

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -246,3 +246,11 @@ v1.12.20
 
 - Android v1.12.16
 - iOS v1.12.16
+
+v1.12.21
+----
+* Add public method `UpdatePostbackConversionValue`
+* Deprecated `registerAppForAdNetworkAttribution` and `updateConversionValue` for iOS 15.4 and later. Added new `updatePostbackConversionValue` method
+
+- Android v1.12.16
+- iOS v1.12.17


### PR DESCRIPTION
**JIRA**:

- https://adromance.atlassian.net/browse/TENJIN-10105

**Proposed Changes:**

- Add Add public method `UpdatePostbackConversionValue`
- Deprecated `registerAppForAdNetworkAttribution` and `updateConversionValue` for iOS 15.4 and later. Added new `updatePostbackConversionValue` method
- Update iOS SDK to 1.12.17

**Steps:**

- [x] Reviewed
- [x] Deployed
