### PR TITLE
build: Extract latest version from RELEASE_NOTES using head instead of tail

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Get latest version from RELEASE_NOTES.md
         id: version
         run: |
-          RAW_VERSION=$(grep -E "^v[0-9]+\.[0-9]+\.[0-9]+" RELEASE_NOTES.md | tail -1 | tr -d '\r')
+          RAW_VERSION=$(grep -E "^v[0-9]+\.[0-9]+\.[0-9]+" RELEASE_NOTES.md | head -1 | tr -d '\r')
           if [[ -z "$RAW_VERSION" ]]; then
             echo "::error::Could not detect version from RELEASE_NOTES.md"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         id: release_notes
         run: |
           RAW_VERSION="${{ steps.version.outputs.raw_version }}"
-          NOTES=$(awk "/^${RAW_VERSION}\$/{found=1; next} /^----\$/{if(found) {capture=1; next}} /^v[0-9]/{if(capture) exit} capture && /^[*-] /{print}" RELEASE_NOTES.md)
+          NOTES=$(awk "/^${RAW_VERSION}\$/{found=1; next} /^----\$/{if(found) {capture=1; next}} /^v[0-9]/{if(capture) exit} capture && /^[*-] /{print}" RELEASE_NOTES.md | sed 's/ \[TENJIN-[0-9]*\]//g')
           {
             echo "notes<<EOF"
             echo "$NOTES"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 v1.19.0
 ----
-* Add prefab object [TENJIN-25954]
-* Update release-please manifest to current version 1.18.0 [TENJIN-28270]
+* Add prefab object
+* Update release-please manifest to current version 1.18.0
 
 - Android v1.20.0
 - iOS v1.17.1
@@ -447,7 +447,7 @@ v1.12.7
 
 v1.12.6
 ----
-* Apple Attribution Token - Add iOS SDK 1.12.6 [TENJIN-7383]
+* Apple Attribution Token - Add iOS SDK 1.12.6
 
 - Android v1.12.5
 - iOS v1.12.6


### PR DESCRIPTION
## Problem

The release workflow was extracting the version using `tail -1`, which gets the **last** matching line in RELEASE_NOTES.md. Since the file is now sorted with newest versions first, this was picking up v1.0.0 instead of v1.19.0, causing incorrect releases.

## Solution

Changed to use `head -1` to extract the first (current) version instead of the last (oldest) version.

## Impact

Future releases will now correctly identify the current version and avoid releasing wrong tags.