### PR TITLE
docs: clarify cache event setting persists across sessions [TENJIN-28758]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ name: Release
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -984,6 +984,16 @@ Tenjin supports the ability to integrate with the Impression Level Ad Revenue (I
 
 This feature allows you to receive events which correspond to your ad revenue which is affected by each advertisement shown to a user. Access to the integration guide is [here](https://tenjin.com/docs/category/ad-revenue-ad-mediation-setup/).
 
+### Custom mediation
+
+If your mediation provider is not on the list above, you can report impressions with the generic custom mediation method, available since v1.17.0. Pass a JSON object string with your impression data and include the revenue as `revenue_decimal` (revenue for this impression) or `revenue_cpm` (revenue per 1,000 impressions). Impressions sent this way are reported under the `custom` mediation source.
+
+```csharp
+BaseTenjin instance = Tenjin.getInstance("<SDK_KEY>");
+string impressionJson = "{\"network_name\":\"my_network\",\"mediation_country\":\"US\",\"currency\":\"USD\",\"ad_unit_id\":\"my_ad_unit_id\",\"ad_format\":\"banner\",\"revenue_decimal\":0.001,\"precision\":\"BID\"}";
+instance.CustomImpressionFromJSON(impressionJson);
+```
+
 # <a id="testing"></a>Testing
 
 You can verify if the integration is working through our <a href="https://www.tenjin.io/dashboard/sdk_diagnostics">Live Test Device Data Tool</a>. Add your `advertising_id` or `IDFA/GAID` to the list of test devices. You can find this under Support -\> <a href="https://www.tenjin.io/dashboard/debug_app_users">Test Devices</a>. Go to the <a href="https://www.tenjin.io/dashboard/sdk_diagnostics">SDK Live page</a> and send the test events from your app. You should see live events come in:

--- a/README.md
+++ b/README.md
@@ -964,6 +964,13 @@ BaseTenjin instance = Tenjin.getInstance("<SDK_KEY>");
 instance.SetCacheEventSetting(true);
 ```
 
+> [!IMPORTANT]
+> This setting is stored on the device and persists across app sessions on both iOS and Android. Once a build has enabled it, removing the `SetCacheEventSetting` call in a later release will **not** disable caching for existing users — the previously stored value stays in effect. To turn it off, explicitly call:
+>
+> ```csharp
+> instance.SetCacheEventSetting(false);
+> ```
+
 ## <a id="ilrd"></a>Impression Level Ad Revenue Integration
 
 Tenjin supports the ability to integrate with the Impression Level Ad Revenue (ILRD) feature from,

--- a/README.md
+++ b/README.md
@@ -986,7 +986,7 @@ This feature allows you to receive events which correspond to your ad revenue wh
 
 ### Custom mediation
 
-If your mediation provider is not on the list above, you can report impressions with the generic custom mediation method, available since v1.17.0. Pass a JSON object string with your impression data and include the revenue as `revenue_decimal` (revenue for this impression) or `revenue_cpm` (revenue per 1,000 impressions). Impressions sent this way are reported under the `custom` mediation source.
+If your mediation provider is not on the list above, you can report impressions with the generic custom mediation method, available since v1.17.0. Pass a JSON object string with your impression data. Required fields are `network_name`, `currency`, and either `revenue_decimal` (revenue for this impression) or `revenue_cpm` (revenue per 1,000 impressions); the full list of accepted fields is in the [ILRD API documentation](https://tenjin.com/docs/impression-level-revenue-data-api-s2s/). Impressions sent this way are reported under the `custom` mediation source, with `ad_revenue_mediation` and the device parameters set automatically by the SDK.
 
 ```csharp
 BaseTenjin instance = Tenjin.getInstance("<SDK_KEY>");

--- a/README.md
+++ b/README.md
@@ -973,16 +973,21 @@ instance.SetCacheEventSetting(true);
 
 ## <a id="ilrd"></a>Impression Level Ad Revenue Integration
 
-Tenjin supports the ability to integrate with the Impression Level Ad Revenue (ILRD) feature from,
-- AppLovin MAX
-- Unity LevelPlay
-- HyperBid
-- AdMob
-- Topon
-- CAS
-- TradPlus
+Tenjin supports the ability to integrate with the Impression Level Ad Revenue (ILRD) feature from the mediation providers below. Most providers offer a `Subscribe...` helper that hooks the mediation callbacks automatically, plus a `...FromJSON` method to forward an impression payload manually; follow the linked guide for the full setup of each provider.
 
-This feature allows you to receive events which correspond to your ad revenue which is affected by each advertisement shown to a user. Access to the integration guide is [here](https://tenjin.com/docs/category/ad-revenue-ad-mediation-setup/).
+| Provider | Methods | Setup guide |
+|----------|---------|-------------|
+| AppLovin MAX | `SubscribeAppLovinImpressions()`, `AppLovinImpressionFromJSON(json)` | [Guide](https://tenjin.com/docs/unity-plugin-applovin-max/) |
+| Unity LevelPlay | `SubscribeLevelPlayRewardedAdImpressions(ad)`, `SubscribeLevelPlayInterstitialAdImpressions(ad)`, `SubscribeLevelPlayBannerAdImpressions(ad)`, `IronSourceImpressionFromJSON(json)` | [Guide](https://tenjin.com/docs/unity-plugin-unity-levelplay/) |
+| AdMob | `SubscribeAdMobBannerViewImpressions(ad, adUnitId)`, `SubscribeAdMobRewardedAdImpressions(ad, adUnitId)`, `SubscribeAdMobInterstitialAdImpressions(ad, adUnitId)`, `SubscribeAdMobRewardedInterstitialAdImpressions(ad, adUnitId)`, `AdMobImpressionFromJSON(json)` | [Guide](https://tenjin.com/docs/unity-plugin-admob/) |
+| HyperBid | `SubscribeHyperBidImpressions()`, `HyperBidImpressionFromJSON(json)` | |
+| TopOn | `SubscribeTopOnImpressions()`, `TopOnImpressionFromJSON(json)` | [Guide](https://tenjin.com/docs/unity-plugin-topon/) |
+| CAS | `SubscribeCASImpressions(manager)`, `SubscribeCASBannerImpressions(bannerView)`, `CASImpressionFromJSON(json)` | [Guide](https://tenjin.com/docs/unity-plugin-cas/) |
+| TradPlus | `SubscribeTradPlusImpressions()`, `TradPlusImpressionFromJSON(json)`, `TradPlusImpressionFromAdInfo(adInfo)` | [Guide](https://tenjin.com/docs/unity-plugin-tradplus/) |
+| CloudX | `SubscribeCloudXImpressions()`, `CloudXImpressionFromJSON(json)` | [Guide](https://tenjin.com/docs/unity-plugin-cloudx/) |
+| Other providers | `CustomImpressionFromJSON(json)` | See [Custom mediation](#custom-mediation) |
+
+This feature allows you to receive events which correspond to your ad revenue which is affected by each advertisement shown to a user. Access to the full documentation is [here](https://tenjin.com/docs/category/ad-revenue/).
 
 ### Custom mediation
 

--- a/README.md
+++ b/README.md
@@ -965,7 +965,7 @@ instance.SetCacheEventSetting(true);
 ```
 
 > [!IMPORTANT]
-> This setting is stored on the device and persists across app sessions on both iOS and Android. Once a build has enabled it, removing the `SetCacheEventSetting` call in a later release will **not** disable caching for existing users — the previously stored value stays in effect. To turn it off, explicitly call:
+> This setting is stored on the device and persists across app sessions on both iOS and Android. Once a build has enabled it, removing the `SetCacheEventSetting` call in a later release will **not** disable caching for existing users, because the previously stored value stays in effect. To turn it off, explicitly call:
 >
 > ```csharp
 > instance.SetCacheEventSetting(false);


### PR DESCRIPTION
## Summary
Documentation additions plus a CI guard:

**Cache event setting persistence.** Adds a note to the *Retry/cache events and IAP* section: `SetCacheEventSetting` is stored on the device (UserDefaults on iOS, SharedPreferences on Android) and persists across app sessions, so removing the call from a later build does **not** disable caching for users who already had it enabled. Apps must call `instance.SetCacheEventSetting(false)` explicitly.

**ILRD provider method reference.** Replaces the plain provider list in the ILRD section with a table mapping each mediation provider to its `Subscribe...` helpers, `...FromJSON` methods and setup guide (per https://tenjin.com/docs/category/ad-revenue/). Also adds CloudX, which the list was missing, and refreshes the docs category link.

**Generic custom mediation ILRD method.** `CustomImpressionFromJSON` (available since v1.17.0, bridging to `customImpressionFromJSON:` on iOS and `eventAdImpressionCustom` on Android) was not documented anywhere. Adds a *Custom mediation* subsection with a payload example, the required fields per the ILRD S2S API (`network_name`, `currency`, `revenue_decimal`/`revenue_cpm`), and a link to the API reference.

**Release workflow guard.** The release workflow previously ran on every push to master and relied on the tag-already-exists check to bail out, leaving a failed run on docs-only merges. Adds `paths-ignore: '**.md'` so markdown-only merges (like this PR) do not run it at all.

## Context
Prompted by a customer support case (cache setting) and docs gaps found while auditing. Companion PRs: tenjin/tenjin-ios-sdk#194, tenjin/tenjin-android-sdk#147.

No SDK code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)